### PR TITLE
fix: url option for ios, add docs

### DIFF
--- a/Detox.js
+++ b/Detox.js
@@ -84,6 +84,7 @@ let waitFor;
  * * `reloadReactNative` - should be enabled for React Native applications.
  * * `reuse` - reuse application for tests. By default, Detox reinstalls and relaunches app.
  * * `registerGlobals` - (default: true) Register Detox helper functions `by`, `element`, `expect`, `waitFor` globally.
+ * * `url` - a URL to open on whenever the app is launched (android) or immediately afterwards (iOS). Useful for opening a bundle URL at the beginning of tests when working with Expo.
  *
  */
 class Detox extends Helper {

--- a/Detox.js
+++ b/Detox.js
@@ -190,6 +190,10 @@ class Detox extends Helper {
       await this.device.reloadReactNative();
     } else {
       await this.device.launchApp({ newInstance: true, url: this.options.url });
+
+      if (this.device.getPlatform() === 'ios' && this.options.url !== undefined) {
+        await this.device.openURL({ url: this.options.url });
+      }
     }
   }
 


### PR DESCRIPTION
A fix and an update to the docs around the launch URL feature submitted in PR #42.

- [x] Fixes support for the URL option  on iOS by also executing `device.openURL`.
  * Without it, the open URL is not respected on (all?) versions of iOS.
  * Utilizing `sourceApp: 'com.apple.mobilesafari'` within `launchApp` instead of a separate `openURL` call was found unreliable.
- [x] Add documentation around the configuration options for `url`.